### PR TITLE
fix: initialize DI container to resolve Container provider not initialized error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 import 'reflect-metadata';
+import './di/container';
 
 export {run} from '@oclif/core'


### PR DESCRIPTION
## Summary
- Fix runtime error "Container provider not initialized" in released commands
- Import DI container module in src/index.ts to ensure proper initialization

## Test plan
- [x] Build project successfully
- [x] Container provider initialization happens at startup
- [x] Commands can resolve dependencies without errors

🤖 Generated with [Claude Code](https://claude.ai/code)