### PR TITLE
Fix bin/dev.js CommonJS compatibility and enhance documentation

### DIFF
--- a/.claude/core.md
+++ b/.claude/core.md
@@ -11,7 +11,17 @@ This is `gcal-commander`, a Google Calendar CLI tool built with the oclif framew
 - `npm run test:file [file(s)]` - Run specific test file(s) or patterns
 - `npm run lint` - Run ESLint
 - `npm run posttest` - Automatically runs lint after tests
-- `./bin/run.js COMMAND` or `gcal COMMAND` - Run CLI commands locally
+
+### CLI Execution Modes
+
+- **Development mode**: `./bin/dev.js COMMAND` 
+  - Uses ts-node to run TypeScript source files directly from src/
+  - Instant changes without compilation - ideal for active development
+  - Requires no build step
+- **Production mode**: `./bin/run.js COMMAND` or `gcal COMMAND`
+  - Uses compiled JavaScript from dist/ directory
+  - Requires `npm run build` before running after code changes
+  - Used for final testing and distribution
 
 ## Architecture
 
@@ -30,7 +40,9 @@ Built on oclif CLI framework:
   - `src/services/calendar.ts` wraps Google Calendar API calls
   - `src/services/config.ts` manages user configuration in JSON format
 - **Tests**: Mirror command structure in `test/commands/` using Mocha and Chai
-- **CLI Entry**: `bin/run.js` points to built commands in `dist/commands/`
+- **CLI Entry**: 
+  - `bin/run.js` points to built commands in `dist/commands/` (production)
+  - `bin/dev.js` loads TypeScript commands from `src/commands/` with ts-node (development)
 - **Configuration**: oclif config in package.json defines bin name "gcal", command discovery, and topics
 
 ## Command Structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,17 +31,21 @@ When working on tasks that require deeper context:
 
 - **Tech Stack**: oclif CLI framework + TypeScript + Google Calendar API
 - **Commands**: `npm test`, `npm run test:file [file(s)]`, `npm run lint`, `npm run build`
-- **Entry Point**: `./bin/run.js` or `gcal` command
+- **Entry Points**: 
+  - **Development**: `./bin/dev.js` (uses TypeScript source files directly with ts-node)
+  - **Production**: `./bin/run.js` or `gcal` (uses compiled JavaScript from dist/)
 - **Base Class**: All commands extend `BaseCommand` with `--quiet` flag support
 - **ESLint**: Uses flat config format (`eslint.config.mjs`) with oclif presets and perfectionist rules
 
 ## Development Workflow
 
 1. Read `.claude/core.md` for architecture patterns
-2. Follow TDD practices from `.claude/tdd.md`
-3. Use oclif logging methods (never console.log)
-4. Separate stdout (data) from stderr (status messages)
-5. Run tests after changes: `npm test`
+2. **Use development mode for active development**: `./bin/dev.js COMMAND` (instant TypeScript changes without build)
+3. Follow TDD practices from `.claude/tdd.md`
+4. Use oclif logging methods (never console.log)
+5. Separate stdout (data) from stderr (status messages)
+6. Run tests after changes: `npm test`
+7. **Use production mode for final testing**: `npm run build && ./bin/run.js COMMAND`
 
 ## Special Commands
 

--- a/README.md
+++ b/README.md
@@ -187,8 +187,14 @@ We welcome contributions to gcal-commander! This project embraces AI-assisted de
 
 1. Fork and clone the repository
 2. Install dependencies: `npm install`
-3. Make your changes
-4. Run tests: `npm test`
+3. **Development workflow**:
+   - **For active development**: Use `./bin/dev.js COMMAND` to run commands directly from TypeScript source files (no build required)
+   - **For final testing**: Use `npm run build && ./bin/run.js COMMAND` to test the production build
+4. Make your changes and run tests: `npm test`
 5. Submit a pull request
+
+**CLI Execution Modes:**
+- `./bin/dev.js` - Development mode (TypeScript source files with ts-node, instant changes)
+- `./bin/run.js` - Production mode (compiled JavaScript from dist/, requires build)
 
 The project uses Husky + lint-staged for automatic code quality checks before commits.

--- a/bin/dev.js
+++ b/bin/dev.js
@@ -1,5 +1,13 @@
-#!/usr/bin/env -S node --loader ts-node/esm --disable-warning=ExperimentalWarning
+#!/usr/bin/env node
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* eslint-disable unicorn/prefer-module */
 
-import {execute} from '@oclif/core'
+// Register ts-node for TypeScript support in development
+require('ts-node/register');
 
-await execute({development: true, dir: import.meta.url})
+// Initialize DI container before running commands
+require('../src/di/container');
+
+const {execute} = require('@oclif/core');
+
+execute({development: true, dir: __dirname});

--- a/bin/run.js
+++ b/bin/run.js
@@ -2,6 +2,9 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 /* eslint-disable unicorn/prefer-module */
 
+// Initialize DI container before running commands
+require('../dist/di/container');
+
 const {execute} = require('@oclif/core')
 
 execute({dir: __dirname})

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,4 +15,11 @@ export default [
       'perfectionist/sort-objects': 'off',
     },
   },
+  {
+    files: ['bin/dev.js'],
+    rules: {
+      'n/no-unpublished-require': 'off',
+      'n/no-missing-require': 'off',
+    },
+  },
 ]


### PR DESCRIPTION
## Summary
- Fix bin/dev.js to work with CommonJS module system (resolves ESM import errors)
- Add DI container initialization to both development and production entry points
- Enhance documentation with clear development workflow guidance

## Changes Made
- **bin/dev.js**: Convert from ESM to CommonJS format, add ts-node registration and DI container initialization
- **bin/run.js**: Add DI container initialization for production mode
- **Documentation Updates**:
  - CLAUDE.md: Add development vs production entry point explanations
  - .claude/core.md: Add CLI execution modes section with detailed workflow
  - README.md: Update development setup with clear execution mode guidance

## Test Plan
- [x] Verify `./bin/dev.js events list` works in development mode
- [x] Verify `./bin/run.js events list` works in production mode
- [x] Both modes properly initialize DI container and execute commands
- [x] Documentation accurately reflects the development workflow

🤖 Generated with [Claude Code](https://claude.ai/code)