### PR TITLE
refactor: simplify IConfigStorage interface and improve test isolation

### DIFF
--- a/src/interfaces/config-storage.ts
+++ b/src/interfaces/config-storage.ts
@@ -1,6 +1,6 @@
 export interface IConfigStorage {
-  exists(path: string): Promise<boolean>;
+  exists(): Promise<boolean>;
   getConfigPath(): string;
-  read(path: string): Promise<string>;
-  write(path: string, content: string): Promise<void>;
+  read(): Promise<string>;
+  write(content: string): Promise<void>;
 }

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -40,11 +40,10 @@ export class ConfigService implements IConfigService {
     if (this.loaded) return;
 
     try {
-      const configPath = this.configStorage.getConfigPath();
-      const exists = await this.configStorage.exists(configPath);
+      const exists = await this.configStorage.exists();
 
       if (exists) {
-        const content = await this.configStorage.read(configPath);
+        const content = await this.configStorage.read();
         this.config = JSON.parse(content);
       } else {
         this.config = {};
@@ -63,9 +62,8 @@ export class ConfigService implements IConfigService {
   }
 
   public async save(): Promise<void> {
-    const configPath = this.configStorage.getConfigPath();
     const content = JSON.stringify(this.config, null, 2);
-    await this.configStorage.write(configPath, content);
+    await this.configStorage.write(content);
   }
 
   public async set(key: string, value: unknown): Promise<void> {

--- a/src/test-utils/mock-factories/config-storage-mock-factory.ts
+++ b/src/test-utils/mock-factories/config-storage-mock-factory.ts
@@ -3,67 +3,59 @@ import * as sinon from 'sinon';
 import { IConfigStorage } from '../../interfaces/config-storage';
 
 export interface ConfigStorageMockOptions {
-  configPath?: string;
-  initialData?: Record<string, string>;
+  exists?: boolean;
+  initialContent?: string;
   readError?: Error;
   writeError?: Error;
 }
 
 export const ConfigStorageMockFactory = {
   create(options: ConfigStorageMockOptions = {}): IConfigStorage & sinon.SinonStubbedInstance<IConfigStorage> {
-    const mock = sinon.createStubInstance<IConfigStorage>(class implements IConfigStorage {
-      async exists(_path: string): Promise<boolean> { 
-        return false; 
-      }
+    const mock = sinon.createStubInstance<IConfigStorage>(
+      class implements IConfigStorage {
+        async exists(): Promise<boolean> {
+          return false;
+        }
 
-      getConfigPath(): string { 
-        return ''; 
-      }
+        getConfigPath(): string {
+          return '';
+        }
 
-      async read(_path: string): Promise<string> { 
-        return ''; 
-      }
+        async read(): Promise<string> {
+          return '';
+        }
 
-      async write(_path: string, _content: string): Promise<void> { 
-        // No implementation needed for stub
-      }
-    });
-    
+        async write(_content: string): Promise<void> {
+          // No implementation needed for stub
+        }
+      },
+    );
+
     // Set up default behaviors
-    const configPath = options.configPath || '/tmp/test-config.json';
-    mock.getConfigPath.returns(configPath);
-    
-    // Set up initial data
-    const initialData = options.initialData || {};
-    for (const [path, content] of Object.entries(initialData)) {
-      mock.read.withArgs(path).resolves(content);
-      mock.exists.withArgs(path).resolves(true);
-    }
-    
-    // Set up default exists behavior (false for unknown paths)
-    mock.exists.callsFake(async (path: string) => Object.hasOwn(initialData, path));
-    
-    // Set up default read behavior (throw for unknown paths)
-    mock.read.callsFake(async (path: string) => {
-      if (Object.hasOwn(initialData, path)) {
-        return initialData[path];
-      }
+    const exists = options.exists ?? false;
+    const initialContent = options.initialContent || '{}';
 
-      throw new Error(`ENOENT: no such file or directory, open '${path}'`);
-    });
-    
+    mock.exists.resolves(exists);
+    mock.getConfigPath.returns('in-memory');
+
+    if (exists) {
+      mock.read.resolves(initialContent);
+    } else {
+      mock.read.rejects(new Error('ENOENT: no such file or directory'));
+    }
+
     // Set up default write behavior
     mock.write.resolves();
-    
+
     // Handle error scenarios
     if (options.readError) {
       mock.read.rejects(options.readError);
     }
-    
+
     if (options.writeError) {
       mock.write.rejects(options.writeError);
     }
-    
+
     return mock;
   },
 };

--- a/test/commands/config.i18n.test.ts
+++ b/test/commands/config.i18n.test.ts
@@ -11,11 +11,10 @@ describe('config i18n integration', () => {
       const { mocks } = TestContainerFactory.create();
       const realI18nService = new I18nService();
       TestContainerFactory.registerService(TOKENS.I18nService, realI18nService);
-      
+
       // Mock config storage methods (ConfigService uses ConfigStorage)
       mocks.configStorage.read.resolves('{}');
       mocks.configStorage.exists.resolves(false);
-      mocks.configStorage.getConfigPath.returns('/mock/path/config.json');
     });
 
     afterEach(() => {
@@ -24,40 +23,40 @@ describe('config i18n integration', () => {
 
     it('should display config list messages in English', async () => {
       const { stderr, stdout } = await runCommand(['config', 'list']);
-      
+
       expect(stderr).to.include('Current configuration:');
-      expect(stderr).to.include('Config file: /mock/path/config.json');
+      expect(stderr).to.include('Config file: in-memory');
       expect(stdout).to.include('No configuration set');
     });
 
     it('should display config get messages in English for unset key', async () => {
       const { stdout } = await runCommand(['config', 'get', 'defaultCalendar']);
-      
+
       expect(stdout).to.include("Configuration key 'defaultCalendar' is not set");
     });
 
     it('should display config set success message in English', async () => {
       const { stdout } = await runCommand(['config', 'set', 'defaultCalendar', 'test@example.com']);
-      
+
       expect(stdout).to.include('Set defaultCalendar = "test@example.com"');
     });
 
     it('should display config unset messages in English', async () => {
       const { stdout } = await runCommand(['config', 'unset', 'defaultCalendar']);
-      
+
       expect(stdout).to.include("Configuration key 'defaultCalendar' is not set");
     });
 
     it('should display config reset confirmation message in English', async () => {
       const { stdout } = await runCommand(['config', 'reset']);
-      
+
       expect(stdout).to.include('This will reset all configuration settings.');
       expect(stdout).to.include('Use --confirm flag to proceed: gcal config reset --confirm');
     });
 
     it('should display config set validation error in English', async () => {
       const result = await runCommand(['config', 'set']);
-      
+
       expect(result.error).to.exist;
       expect(result.error?.message).to.include('Key and value are required for set command');
       expect(result.error?.message).to.include('Usage: gcal config set <key> <value>');
@@ -65,14 +64,14 @@ describe('config i18n integration', () => {
 
     it('should display invalid number value error in English', async () => {
       const result = await runCommand(['config', 'set', 'events.maxResults', 'not-a-number']);
-      
+
       expect(result.error).to.exist;
       expect(result.error?.message).to.include('Invalid number value for events.maxResults: not-a-number');
     });
 
     it('should display invalid configuration key error in English', async () => {
       const result = await runCommand(['config', 'get', 'invalid.key']);
-      
+
       expect(result.error).to.exist;
       expect(result.error?.message).to.include('Invalid configuration key: invalid.key');
       expect(result.error?.message).to.include('Valid keys:');
@@ -80,7 +79,7 @@ describe('config i18n integration', () => {
 
     it('should display missing key parameter error in English', async () => {
       const result = await runCommand(['config', 'get']);
-      
+
       expect(result.error).to.exist;
       expect(result.error?.message).to.include('Key is required for get command');
       expect(result.error?.message).to.include('Usage: gcal config get <key>');
@@ -94,11 +93,10 @@ describe('config i18n integration', () => {
       await realI18nService.init();
       await realI18nService.changeLanguage('ja');
       TestContainerFactory.registerService(TOKENS.I18nService, realI18nService);
-      
+
       // Mock config storage methods (ConfigService uses ConfigStorage)
       mocks.configStorage.read.resolves('{}');
       mocks.configStorage.exists.resolves(false);
-      mocks.configStorage.getConfigPath.returns('/mock/path/config.json');
     });
 
     afterEach(() => {
@@ -107,40 +105,40 @@ describe('config i18n integration', () => {
 
     it('should display config list messages in Japanese', async () => {
       const { stderr, stdout } = await runCommand(['config', 'list']);
-      
+
       expect(stderr).to.include('現在の設定:');
-      expect(stderr).to.include('設定ファイル: /mock/path/config.json');
+      expect(stderr).to.include('設定ファイル: in-memory');
       expect(stdout).to.include('設定がありません');
     });
 
     it('should display config get messages in Japanese for unset key', async () => {
       const { stdout } = await runCommand(['config', 'get', 'defaultCalendar']);
-      
+
       expect(stdout).to.include("設定キー 'defaultCalendar' は設定されていません");
     });
 
     it('should display config set success message in Japanese', async () => {
       const { stdout } = await runCommand(['config', 'set', 'defaultCalendar', 'test@example.com']);
-      
+
       expect(stdout).to.include('defaultCalendar = "test@example.com" に設定しました');
     });
 
     it('should display config unset messages in Japanese', async () => {
       const { stdout } = await runCommand(['config', 'unset', 'defaultCalendar']);
-      
+
       expect(stdout).to.include("設定キー 'defaultCalendar' は設定されていません");
     });
 
     it('should display config reset confirmation message in Japanese', async () => {
       const { stdout } = await runCommand(['config', 'reset']);
-      
+
       expect(stdout).to.include('すべての設定をリセットします。');
       expect(stdout).to.include('実行するには --confirm フラグを使用してください: gcal config reset --confirm');
     });
 
     it('should display config set validation error in Japanese', async () => {
       const result = await runCommand(['config', 'set']);
-      
+
       expect(result.error).to.exist;
       expect(result.error?.message).to.include('キーと値は set コマンドで必須です');
       expect(result.error?.message).to.include('使用方法: gcal config set <key> <value>');
@@ -148,14 +146,14 @@ describe('config i18n integration', () => {
 
     it('should display invalid number value error in Japanese', async () => {
       const result = await runCommand(['config', 'set', 'events.maxResults', 'not-a-number']);
-      
+
       expect(result.error).to.exist;
       expect(result.error?.message).to.include('events.maxResults の数値が無効です: not-a-number');
     });
 
     it('should display invalid configuration key error in Japanese', async () => {
       const result = await runCommand(['config', 'get', 'invalid.key']);
-      
+
       expect(result.error).to.exist;
       expect(result.error?.message).to.include('無効な設定キー: invalid.key');
       expect(result.error?.message).to.include('有効なキー:');
@@ -163,7 +161,7 @@ describe('config i18n integration', () => {
 
     it('should display missing key parameter error in Japanese', async () => {
       const result = await runCommand(['config', 'get']);
-      
+
       expect(result.error).to.exist;
       expect(result.error?.message).to.include('get コマンドにはキーが必要です');
       expect(result.error?.message).to.include('使用方法: gcal config get <key>');


### PR DESCRIPTION
## Summary
- Simplify IConfigStorage interface by removing path arguments from methods
- Add InMemoryConfigStorage for better test isolation 
- Fix i18n test failures caused by persistent config state between tests
- Remove unnecessary GCAL_COMMANDER_CONFIG_PATH environment variable logic

## Key Changes
- **IConfigStorage Interface**: Removed path parameters, now uses content-based operations
- **InMemoryConfigStorage**: New implementation for test isolation using plain object storage
- **Test Container**: Updated setupTestContainer to use InMemoryConfigStorage instead of FileSystemConfigStorage
- **Config Tests**: Simplified by removing temp directory management and environment variable setup
- **i18n Tests**: Fixed language isolation issues between test cases

## Breaking Changes
- IConfigStorage interface signature changed (internal implementation detail)
- FileSystemConfigStorage now manages paths internally

## Test Results
- ✅ All 226 tests passing
- ✅ Linting passes
- ✅ i18n functionality working correctly in both English and Japanese
- ✅ Test isolation properly maintained

🤖 Generated with [Claude Code](https://claude.ai/code)