### PR TITLE
feat: migrate coverage reporting from Coveralls to Codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Run tests with coverage
       run: npm run coverage
     
-    - name: Coveralls
-      uses: coverallsapp/github-action@v2
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v5
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A command-line interface for Google Calendar operations. Manage your Google Cale
 [![oclif](https://img.shields.io/badge/cli-oclif-brightgreen.svg)](https://oclif.io)
 [![Version](https://img.shields.io/npm/v/gcal-commander.svg)](https://npmjs.org/package/gcal-commander)
 [![Downloads/week](https://img.shields.io/npm/dw/gcal-commander.svg)](https://npmjs.org/package/gcal-commander)
-[![Coverage Status](https://coveralls.io/repos/github/buko106/gcal-commander/badge.svg)](https://coveralls.io/github/buko106/gcal-commander)
+[![codecov](https://codecov.io/github/buko106/gcal-commander/graph/badge.svg?token=DQUL68E057)](https://codecov.io/github/buko106/gcal-commander)
 
 ## Features
 


### PR DESCRIPTION
## Summary

- Migrate from Coveralls to Codecov for test coverage reporting
- Replace `coverallsapp/github-action` with `codecov/codecov-action@v5`
- Use `CODECOV_TOKEN` secret for authentication

## Changes Made

- Updated `.github/workflows/coverage.yml` to use Codecov action
- Changed authentication from GitHub token to Codecov token
- Updated step name for clarity

## Test Plan

- [ ] Verify workflow runs successfully with Codecov integration
- [ ] Confirm coverage reports are uploaded to Codecov dashboard
- [ ] Check that existing coverage generation (`npm run coverage`) still works
- [ ] Validate that CODECOV_TOKEN secret is properly configured

🤖 Generated with [Claude Code](https://claude.ai/code)