### PR TITLE
docs: add missing --fields flag documentation across all languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A command-line interface for Google Calendar operations. Manage your Google Cale
 - 🔐 **Secure OAuth2 authentication** - One-time setup with automatic token refresh
 - 💻 **Terminal-friendly output** - Clean table format or JSON for scripting
 - 🔇 **Quiet mode support** - Use `--quiet` flag to suppress status messages for scripting
+- 🎯 **Customizable table columns** - Use `--fields` flag to show only specific columns in table format
 - 🚀 **Fast and lightweight** - Built with oclif framework
 
 ## Languages
@@ -124,6 +125,10 @@ gcal events list --max-results 5 --days 7
 
 # Use quiet mode for scripting (suppresses status messages, keeps data output)
 gcal events list --quiet --format json | jq '.[] | .summary'
+
+# Customize table columns using --fields flag
+gcal events list --fields title,date,time
+gcal calendars list --fields name,id
 
 # Configuration examples
 gcal config set defaultCalendar work@company.com

--- a/docs/calendars-list.md
+++ b/docs/calendars-list.md
@@ -12,6 +12,7 @@ gcal calendars list [options]
 
 | Flag | Short | Description | Default |
 |------|-------|-------------|---------|
+| `--fields` | | Comma-separated list of fields to display in table format | All fields |
 | `--format` | `-f` | Output format (table, json, or pretty-json) | `table` |
 | `--quiet` | `-q` | Suppress non-essential output (status messages, progress indicators) | `false` |
 
@@ -28,6 +29,12 @@ gcal calendars list --format json
 
 # List calendars quietly (no status messages)
 gcal calendars list --quiet
+
+# Show only calendar names and IDs
+gcal calendars list --fields name,id
+
+# Show only names (useful for quick overview)
+gcal calendars list --fields name
 ```
 
 ### Output Formats
@@ -65,6 +72,35 @@ Available Calendars (3 found):
   }
 ]
 ```
+
+## Table Field Customization
+
+You can customize which columns are displayed in table format using the `--fields` flag:
+
+### Available Fields
+- `name` - Calendar name/summary
+- `id` - Calendar ID
+- `access` - Access role (owner, reader, writer, etc.)
+- `primary` - Primary calendar indicator
+- `description` - Calendar description
+- `color` - Calendar color
+
+### Examples
+```bash
+# Show only name and ID (most common use case)
+gcal calendars list --fields name,id
+
+# Show name, ID, and access role
+gcal calendars list --fields name,id,access
+
+# Show only names for quick overview
+gcal calendars list --fields name
+
+# Show calendar colors and access
+gcal calendars list --fields name,color,access
+```
+
+**Note**: The `--fields` flag only affects table format output. JSON output always includes all available fields.
 
 ## Use Cases
 

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -19,6 +19,7 @@ Eine Befehlszeilenschnittstelle für Google Calendar-Operationen. Verwalten Sie 
 - 🔐 **Sichere OAuth2-Authentifizierung** - Einmalige Einrichtung mit automatischer Token-Aktualisierung
 - 💻 **Terminal-freundliche Ausgabe** - Sauberes Tabellenformat oder JSON für Skripting
 - 🔇 **Unterstützung für stillen Modus** - Verwenden Sie die `--quiet`-Flagge, um Statusmeldungen für Skripting zu unterdrücken
+- 🎯 **Anpassbare Tabellenspalten** - Verwenden Sie die `--fields`-Flagge, um nur bestimmte Spalten im Tabellenformat anzuzeigen
 - 🚀 **Schnell und leichtgewichtig** - Mit dem oclif-Framework erstellt
 
 ## Sprachen
@@ -114,6 +115,10 @@ gcal events list --max-results 5 --days 7
 
 # Stillen Modus für Skripting verwenden (unterdrückt Statusmeldungen)
 gcal events list --quiet --format json | jq '.[] | .summary'
+
+# Tabellenspalten anpassen
+gcal events list --fields title,date,time
+gcal calendars list --fields name,id
 
 # Konfigurationsbeispiele
 gcal config set defaultCalendar work@company.com

--- a/docs/de/calendars-list.md
+++ b/docs/de/calendars-list.md
@@ -12,6 +12,7 @@ gcal calendars list [optionen]
 
 | Flag | Kurz | Beschreibung | Standard |
 |------|------|--------------|----------|
+| `--fields` | | Kommagetrennte Liste der Felder für Tabellenformat | Alle Felder |
 | `--format` | `-f` | Ausgabeformat (table, json, pretty-json) | `table` |
 | `--quiet` | `-q` | Nicht-wesentliche Ausgabe ausblenden (Statusmeldungen, Fortschrittsanzeigen) | `false` |
 
@@ -28,6 +29,12 @@ gcal calendars list --format json
 
 # Kalender stumm auflisten (ohne Statusmeldungen)
 gcal calendars list --quiet
+
+# Nur Kalendernamen und IDs anzeigen
+gcal calendars list --fields name,id
+
+# Nur Namen anzeigen (für schnelle Übersicht)
+gcal calendars list --fields name
 ```
 
 ### Ausgabeformate
@@ -65,6 +72,35 @@ Verfügbare Kalender (3 gefunden):
   }
 ]
 ```
+
+## Tabellenfeld-Anpassung
+
+Sie können anpassen, welche Spalten im Tabellenformat angezeigt werden, indem Sie die `--fields`-Flagge verwenden:
+
+### Verfügbare Felder
+- `name` - Kalendername/-zusammenfassung
+- `id` - Kalender-ID
+- `access` - Zugriffsrolle (owner, reader, writer, etc.)
+- `primary` - Primärkalender-Indikator
+- `description` - Kalenderbeschreibung
+- `color` - Kalenderfarbe
+
+### Beispiele
+```bash
+# Nur Name und ID anzeigen (häufigster Anwendungsfall)
+gcal calendars list --fields name,id
+
+# Name, ID und Zugriffsrolle anzeigen
+gcal calendars list --fields name,id,access
+
+# Nur Namen für schnelle Übersicht anzeigen
+gcal calendars list --fields name
+
+# Kalenderfarben und Zugriff anzeigen
+gcal calendars list --fields name,color,access
+```
+
+**Hinweis**: Die `--fields`-Flagge wirkt nur auf die Tabellenformat-Ausgabe. JSON-Ausgabe enthält immer alle verfügbaren Felder.
 
 ## Anwendungsfälle
 

--- a/docs/de/events-create.md
+++ b/docs/de/events-create.md
@@ -27,6 +27,7 @@ gcal events create <zusammenfassung> [optionen]
 | `--description` | | Beschreibung des Ereignisses | - |
 | `--attendees` | | Kommagetrennte Liste von Teilnehmer-E-Mail-Adressen | - |
 | `--send-updates` | | Ereigniseinladungen senden (all/externalOnly/none) | `none` |
+| `--fields` | | Kommagetrennte Liste der Felder für Tabellenformat | Alle Felder |
 | `--format` | `-f` | Ausgabeformat (table, json, pretty-json) | `table` |
 | `--quiet` | `-q` | Nicht-wesentliche Ausgabe ausblenden (Statusmeldungen, Fortschrittsanzeigen) | `false` |
 

--- a/docs/de/events-list.md
+++ b/docs/de/events-list.md
@@ -19,6 +19,7 @@ gcal events list [kalender] [optionen]
 | Flag | Kurz | Beschreibung | Standard |
 |------|------|--------------|----------|
 | `--days` | `-d` | Anzahl der Tage in die Zukunft (1-365) | `30` |
+| `--fields` | | Kommagetrennte Liste der Felder für Tabellenformat | Alle Felder |
 | `--format` | `-f` | Ausgabeformat (table, json, pretty-json) | `table` |
 | `--max-results` | `-n` | Maximale Anzahl zurückzugebender Ereignisse (1-100) | `10` |
 | `--quiet` | `-q` | Nicht-wesentliche Ausgabe ausblenden (Statusmeldungen, Fortschrittsanzeigen) | `false` |
@@ -65,6 +66,10 @@ gcal events list --quiet --format json | jq '.[] | .summary'
 gcal config set defaultCalendar work@company.com
 gcal config set events.days 14
 gcal events list  # Verwendet work@company.com für 14 Tage
+
+# Tabellenspalten anpassen
+gcal events list --fields title,date,time
+gcal events list --fields title,location --max-results 20
 ```
 
 ### Ausgabeformate
@@ -97,6 +102,31 @@ Bevorstehende Ereignisse (2 gefunden):
   }
 ]
 ```
+
+## Tabellenfeld-Anpassung
+
+Sie können anpassen, welche Spalten im Tabellenformat angezeigt werden, indem Sie die `--fields`-Flagge verwenden:
+
+### Verfügbare Felder
+- `title` - Ereignistitel/-zusammenfassung
+- `date` - Ereignisdatum
+- `time` - Ereigniszeit
+- `location` - Ereignisort
+- `description` - Ereignisbeschreibung
+
+### Beispiele
+```bash
+# Nur Titel und Datum anzeigen
+gcal events list --fields title,date
+
+# Titel, Zeit und Ort anzeigen
+gcal events list --fields title,time,location
+
+# Nur Titel anzeigen (für schnelle Übersicht)
+gcal events list --fields title
+```
+
+**Hinweis**: Die `--fields`-Flagge wirkt nur auf die Tabellenformat-Ausgabe. JSON-Ausgabe enthält immer alle verfügbaren Felder.
 
 ## Zeitbereiche und Limits
 

--- a/docs/de/events-show.md
+++ b/docs/de/events-show.md
@@ -19,6 +19,7 @@ gcal events show <event-id> [optionen]
 | Flag | Kurz | Beschreibung | Standard |
 |------|------|--------------|----------|
 | `--calendar` | `-c` | Kalender-ID, in dem das Ereignis existiert | `primary` |
+| `--fields` | | Kommagetrennte Liste der Felder für Tabellenformat | Alle Felder |
 | `--format` | `-f` | Ausgabeformat (table, json, pretty-json) | `table` |
 | `--quiet` | `-q` | Nicht-wesentliche Ausgabe ausblenden (Statusmeldungen, Fortschrittsanzeigen) | `false` |
 

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -19,6 +19,7 @@ Una interfaz de línea de comandos para operaciones de Google Calendar. Gestiona
 - 🔐 **Autenticación OAuth2 segura** - Configuración única con actualización automática de tokens
 - 💻 **Salida amigable para terminal** - Formato de tabla limpio o JSON para scripting
 - 🔇 **Soporte para modo silencioso** - Usa la bandera `--quiet` para suprimir mensajes de estado en scripts
+- 🎯 **Columnas de tabla personalizables** - Usa la bandera `--fields` para mostrar solo columnas específicas en formato tabla
 - 🚀 **Rápido y ligero** - Construido con el framework oclif
 
 ## Idiomas
@@ -124,6 +125,10 @@ gcal events list --max-results 5 --days 7
 
 # Usar modo silencioso para scripting (suprime mensajes de estado, mantiene salida de datos)
 gcal events list --quiet --format json | jq '.[] | .summary'
+
+# Personalizar columnas de tabla
+gcal events list --fields title,date,time
+gcal calendars list --fields name,id
 
 # Ejemplos de configuración
 gcal config set defaultCalendar work@company.com

--- a/docs/es/calendars-list.md
+++ b/docs/es/calendars-list.md
@@ -12,6 +12,7 @@ gcal calendars list [opciones]
 
 | Bandera | Abrev. | Descripción | Por defecto |
 |---------|--------|-------------|-------------|
+| `--fields` | | Lista separada por comas de campos a mostrar en formato tabla | Todos los campos |
 | `--format` | `-f` | Formato de salida (table, json, pretty-json) | `table` |
 | `--quiet` | `-q` | Ocultar salida no esencial (mensajes de estado, indicadores de progreso) | `false` |
 
@@ -28,6 +29,12 @@ gcal calendars list --format json
 
 # Listar calendarios silenciosamente (sin mensajes de estado)
 gcal calendars list --quiet
+
+# Mostrar solo nombres de calendarios e IDs
+gcal calendars list --fields name,id
+
+# Mostrar solo nombres (para vista rápida)
+gcal calendars list --fields name
 ```
 
 ### Formatos de salida
@@ -65,6 +72,35 @@ Calendarios disponibles (3 encontrados):
   }
 ]
 ```
+
+## Personalización de campos de tabla
+
+Puedes personalizar qué columnas se muestran en formato tabla usando la bandera `--fields`:
+
+### Campos disponibles
+- `name` - Nombre/resumen del calendario
+- `id` - ID del calendario
+- `access` - Rol de acceso (owner, reader, writer, etc.)
+- `primary` - Indicador de calendario principal
+- `description` - Descripción del calendario
+- `color` - Color del calendario
+
+### Ejemplos
+```bash
+# Mostrar solo nombre e ID (caso de uso más común)
+gcal calendars list --fields name,id
+
+# Mostrar nombre, ID y rol de acceso
+gcal calendars list --fields name,id,access
+
+# Mostrar solo nombres para vista rápida
+gcal calendars list --fields name
+
+# Mostrar colores de calendarios y acceso
+gcal calendars list --fields name,color,access
+```
+
+**Nota**: La bandera `--fields` solo afecta la salida en formato tabla. La salida JSON siempre incluye todos los campos disponibles.
 
 ## Casos de uso
 

--- a/docs/es/events-create.md
+++ b/docs/es/events-create.md
@@ -27,6 +27,7 @@ gcal events create <resumen> [opciones]
 | `--description` | | Descripción del evento | - |
 | `--attendees` | | Lista separada por comas de direcciones de correo de asistentes | - |
 | `--send-updates` | | Enviar invitaciones de evento (all/externalOnly/none) | `none` |
+| `--fields` | | Lista separada por comas de campos a mostrar en formato tabla | Todos los campos |
 | `--format` | `-f` | Formato de salida (table, json, pretty-json) | `table` |
 | `--quiet` | `-q` | Ocultar salida no esencial (mensajes de estado, indicadores de progreso) | `false` |
 

--- a/docs/es/events-list.md
+++ b/docs/es/events-list.md
@@ -19,6 +19,7 @@ gcal events list [calendario] [opciones]
 | Bandera | Abrev. | Descripción | Por defecto |
 |---------|--------|-------------|-------------|
 | `--days` | `-d` | Número de días a buscar hacia adelante (1-365) | `30` |
+| `--fields` | | Lista separada por comas de campos a mostrar en formato tabla | Todos los campos |
 | `--format` | `-f` | Formato de salida (table, json, pretty-json) | `table` |
 | `--max-results` | `-n` | Número máximo de eventos a devolver (1-100) | `10` |
 | `--quiet` | `-q` | Ocultar salida no esencial (mensajes de estado, indicadores de progreso) | `false` |
@@ -65,6 +66,10 @@ gcal events list --quiet --format json | jq '.[] | .summary'
 gcal config set defaultCalendar work@company.com
 gcal config set events.days 14
 gcal events list  # Usa work@company.com por 14 días
+
+# Personalizar columnas de tabla
+gcal events list --fields title,date,time
+gcal events list --fields title,location --max-results 20
 ```
 
 ### Formatos de salida
@@ -97,6 +102,31 @@ Próximos eventos (2 encontrados):
   }
 ]
 ```
+
+## Personalización de campos de tabla
+
+Puedes personalizar qué columnas se muestran en formato tabla usando la bandera `--fields`:
+
+### Campos disponibles
+- `title` - Título/resumen del evento
+- `date` - Fecha del evento
+- `time` - Hora del evento
+- `location` - Ubicación del evento
+- `description` - Descripción del evento
+
+### Ejemplos
+```bash
+# Mostrar solo título y fecha
+gcal events list --fields title,date
+
+# Mostrar título, hora y ubicación
+gcal events list --fields title,time,location
+
+# Mostrar solo títulos (para vista rápida)
+gcal events list --fields title
+```
+
+**Nota**: La bandera `--fields` solo afecta la salida en formato tabla. La salida JSON siempre incluye todos los campos disponibles.
 
 ## Rangos de tiempo y límites
 

--- a/docs/es/events-show.md
+++ b/docs/es/events-show.md
@@ -19,6 +19,7 @@ gcal events show <event-id> [opciones]
 | Bandera | Abrev. | Descripción | Por defecto |
 |---------|--------|-------------|-------------|
 | `--calendar` | `-c` | ID del calendario donde existe el evento | `primary` |
+| `--fields` | | Lista separada por comas de campos a mostrar en formato tabla | Todos los campos |
 | `--format` | `-f` | Formato de salida (table, json, pretty-json) | `table` |
 | `--quiet` | `-q` | Ocultar salida no esencial (mensajes de estado, indicadores de progreso) | `false` |
 

--- a/docs/events-create.md
+++ b/docs/events-create.md
@@ -27,6 +27,7 @@ gcal events create <summary> [options]
 | `--description` | | Event description | - |
 | `--attendees` | | Comma-separated list of attendee emails | - |
 | `--send-updates` | | Send event invitations (all/externalOnly/none) | `none` |
+| `--fields` | | Comma-separated list of fields to display in table format | All fields |
 | `--format` | `-f` | Output format (table, json, or pretty-json) | `table` |
 | `--quiet` | `-q` | Suppress non-essential output (status messages, progress indicators) | `false` |
 

--- a/docs/events-list.md
+++ b/docs/events-list.md
@@ -19,6 +19,7 @@ gcal events list [calendar] [options]
 | Flag | Short | Description | Default |
 |------|-------|-------------|---------|
 | `--days` | `-d` | Number of days to look ahead (1-365) | `30` |
+| `--fields` | | Comma-separated list of fields to display in table format | All fields |
 | `--format` | `-f` | Output format (table, json, or pretty-json) | `table` |
 | `--max-results` | `-n` | Maximum number of events to return (1-100) | `10` |
 | `--quiet` | `-q` | Suppress non-essential output (status messages, progress indicators) | `false` |
@@ -65,6 +66,10 @@ gcal events list --quiet --format json | jq '.[] | .summary'
 gcal config set defaultCalendar work@company.com
 gcal config set events.days 14
 gcal events list  # Uses work@company.com for 14 days
+
+# Customize table columns
+gcal events list --fields title,date,time
+gcal events list --fields title,location --max-results 20
 ```
 
 ### Output Formats
@@ -97,6 +102,31 @@ Upcoming Events (2 found):
   }
 ]
 ```
+
+## Table Field Customization
+
+You can customize which columns are displayed in table format using the `--fields` flag:
+
+### Available Fields
+- `title` - Event title/summary
+- `date` - Event date 
+- `time` - Event time
+- `location` - Event location
+- `description` - Event description
+
+### Examples
+```bash
+# Show only title and date
+gcal events list --fields title,date
+
+# Show title, time, and location
+gcal events list --fields title,time,location
+
+# Show only titles (useful for quick overview)
+gcal events list --fields title
+```
+
+**Note**: The `--fields` flag only affects table format output. JSON output always includes all available fields.
 
 ## Time Range and Limits
 

--- a/docs/events-show.md
+++ b/docs/events-show.md
@@ -19,6 +19,7 @@ gcal events show <event-id> [options]
 | Flag | Short | Description | Default |
 |------|-------|-------------|---------|
 | `--calendar` | `-c` | Calendar ID where the event is located | `primary` |
+| `--fields` | | Comma-separated list of fields to display in table format | All fields |
 | `--format` | `-f` | Output format (table, json, or pretty-json) | `table` |
 | `--quiet` | `-q` | Suppress non-essential output (status messages, progress indicators) | `false` |
 

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -19,6 +19,7 @@ Une interface en ligne de commande pour les opérations Google Calendar. Gérez 
 - 🔐 **Authentification OAuth2 sécurisée** - Configuration unique avec actualisation automatique du token
 - 💻 **Sortie conviviale pour le terminal** - Format de tableau propre ou JSON pour les scripts
 - 🔇 **Support du mode silencieux** - Utilisez le flag `--quiet` pour supprimer les messages de statut dans les scripts
+- 🎯 **Colonnes de tableau personnalisables** - Utilisez le flag `--fields` pour afficher seulement des colonnes spécifiques en format tableau
 - 🚀 **Rapide et léger** - Construit avec le framework oclif
 
 ## Langues
@@ -123,6 +124,10 @@ gcal events list --max-results 5 --days 7
 
 # Utiliser le mode silencieux pour les scripts (supprime les messages de statut, conserve la sortie de données)
 gcal events list --quiet --format json | jq '.[] | .summary'
+
+# Personnaliser les colonnes de tableau
+gcal events list --fields title,date,time
+gcal calendars list --fields name,id
 
 # Exemples de configuration
 gcal config set defaultCalendar work@company.com

--- a/docs/fr/calendars-list.md
+++ b/docs/fr/calendars-list.md
@@ -12,6 +12,7 @@ gcal calendars list [options]
 
 | Drapeau | Abrév. | Description | Par défaut |
 |---------|--------|-------------|------------|
+| `--fields` | | Liste séparée par des virgules des champs à afficher en format tableau | Tous les champs |
 | `--format` | `-f` | Format de sortie (table, json, pretty-json) | `table` |
 | `--quiet` | `-q` | Masquer la sortie non essentielle (messages de statut, indicateurs de progression) | `false` |
 
@@ -28,6 +29,12 @@ gcal calendars list --format json
 
 # Lister les calendriers silencieusement (sans messages de statut)
 gcal calendars list --quiet
+
+# Afficher seulement les noms de calendriers et IDs
+gcal calendars list --fields name,id
+
+# Afficher seulement les noms (pour aperçu rapide)
+gcal calendars list --fields name
 ```
 
 ### Formats de sortie
@@ -65,6 +72,35 @@ Calendriers disponibles (3 trouvés) :
   }
 ]
 ```
+
+## Personnalisation des champs de tableau
+
+Vous pouvez personnaliser les colonnes affichées en format tableau en utilisant le flag `--fields` :
+
+### Champs disponibles
+- `name` - Nom/résumé du calendrier
+- `id` - ID du calendrier
+- `access` - Rôle d'accès (owner, reader, writer, etc.)
+- `primary` - Indicateur de calendrier principal
+- `description` - Description du calendrier
+- `color` - Couleur du calendrier
+
+### Exemples
+```bash
+# Afficher seulement le nom et l'ID (cas d'utilisation le plus courant)
+gcal calendars list --fields name,id
+
+# Afficher nom, ID et rôle d'accès
+gcal calendars list --fields name,id,access
+
+# Afficher seulement les noms pour aperçu rapide
+gcal calendars list --fields name
+
+# Afficher les couleurs de calendriers et l'accès
+gcal calendars list --fields name,color,access
+```
+
+**Note** : Le flag `--fields` n'affecte que la sortie en format tableau. La sortie JSON inclut toujours tous les champs disponibles.
 
 ## Cas d'utilisation
 

--- a/docs/fr/events-create.md
+++ b/docs/fr/events-create.md
@@ -27,6 +27,7 @@ gcal events create <résumé> [options]
 | `--description` | | Description de l'événement | - |
 | `--attendees` | | Liste séparée par des virgules d'adresses e-mail des participants | - |
 | `--send-updates` | | Envoyer des invitations d'événement (all/externalOnly/none) | `none` |
+| `--fields` | | Liste séparée par des virgules des champs à afficher en format tableau | Tous les champs |
 | `--format` | `-f` | Format de sortie (table, json, pretty-json) | `table` |
 | `--quiet` | `-q` | Masquer la sortie non essentielle (messages de statut, indicateurs de progression) | `false` |
 

--- a/docs/fr/events-list.md
+++ b/docs/fr/events-list.md
@@ -19,6 +19,7 @@ gcal events list [calendrier] [options]
 | Drapeau | Abrév. | Description | Par défaut |
 |---------|--------|-------------|------------|
 | `--days` | `-d` | Nombre de jours à rechercher dans le futur (1-365) | `30` |
+| `--fields` | | Liste séparée par des virgules des champs à afficher en format tableau | Tous les champs |
 | `--format` | `-f` | Format de sortie (table, json, pretty-json) | `table` |
 | `--max-results` | `-n` | Nombre maximum d'événements à retourner (1-100) | `10` |
 | `--quiet` | `-q` | Masquer la sortie non essentielle (messages de statut, indicateurs de progression) | `false` |
@@ -65,6 +66,10 @@ gcal events list --quiet --format json | jq '.[] | .summary'
 gcal config set defaultCalendar work@company.com
 gcal config set events.days 14
 gcal events list  # Utilise work@company.com pour 14 jours
+
+# Personnaliser les colonnes de tableau
+gcal events list --fields title,date,time
+gcal events list --fields title,location --max-results 20
 ```
 
 ### Formats de sortie
@@ -97,6 +102,31 @@ gcal events list  # Utilise work@company.com pour 14 jours
   }
 ]
 ```
+
+## Personnalisation des champs de tableau
+
+Vous pouvez personnaliser les colonnes affichées en format tableau en utilisant le flag `--fields` :
+
+### Champs disponibles
+- `title` - Titre/résumé de l'événement
+- `date` - Date de l'événement
+- `time` - Heure de l'événement
+- `location` - Lieu de l'événement
+- `description` - Description de l'événement
+
+### Exemples
+```bash
+# Afficher seulement le titre et la date
+gcal events list --fields title,date
+
+# Afficher titre, heure et lieu
+gcal events list --fields title,time,location
+
+# Afficher seulement les titres (pour aperçu rapide)
+gcal events list --fields title
+```
+
+**Note** : Le flag `--fields` n'affecte que la sortie en format tableau. La sortie JSON inclut toujours tous les champs disponibles.
 
 ## Plages de temps et limites
 

--- a/docs/fr/events-show.md
+++ b/docs/fr/events-show.md
@@ -19,6 +19,7 @@ gcal events show <event-id> [options]
 | Drapeau | Abrév. | Description | Par défaut |
 |---------|--------|-------------|------------|
 | `--calendar` | `-c` | ID du calendrier où l'événement existe | `primary` |
+| `--fields` | | Liste séparée par des virgules des champs à afficher en format tableau | Tous les champs |
 | `--format` | `-f` | Format de sortie (table, json, pretty-json) | `table` |
 | `--quiet` | `-q` | Masquer la sortie non essentielle (messages de statut, indicateurs de progression) | `false` |
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -30,6 +30,7 @@ Google Calendarの操作を行うコマンドラインインターフェース�
 - 🔐 **安全なOAuth2認証** - 一度の設定でトークンの自動更新
 - 💻 **ターミナル向け出力** - スクリプト用のテーブル形式またはJSON形式
 - 🔇 **静寂モードサポート** - スクリプト用に`--quiet`フラグでステータスメッセージを非表示
+- 🎯 **カスタマイズ可能なテーブル列** - `--fields`フラグでテーブル形式の特定列のみを表示
 - 🚀 **高速・軽量** - oclifフレームワークで構築
 
 ## インストール
@@ -125,6 +126,10 @@ gcal events list --max-results 5 --days 7
 
 # スクリプト用の静寂モード（ステータスメッセージを非表示、データ出力は維持）
 gcal events list --quiet --format json | jq '.[] | .summary'
+
+# --fieldsフラグでテーブル列をカスタマイズ
+gcal events list --fields title,date,time
+gcal calendars list --fields name,id
 
 # 設定例
 gcal config set defaultCalendar work@company.com

--- a/docs/ja/calendars-list.md
+++ b/docs/ja/calendars-list.md
@@ -12,6 +12,7 @@ gcal calendars list [options]
 
 | フラグ | 短縮形 | 説明 | デフォルト |
 |--------|--------|------|-----------|
+| `--fields` | | テーブル形式で表示するフィールドのカンマ区切りリスト | すべてのフィールド |
 | `--format` | `-f` | 出力形式（table、json、pretty-json） | `table` |
 | `--quiet` | `-q` | 重要でない出力を非表示（ステータスメッセージ、進行状況表示） | `false` |
 
@@ -28,6 +29,12 @@ gcal calendars list --format json
 
 # カレンダーを静寂に一覧表示（ステータスメッセージなし）
 gcal calendars list --quiet
+
+# カレンダー名とIDのみ表示
+gcal calendars list --fields name,id
+
+# カレンダー名のみ表示（クイック概要用）
+gcal calendars list --fields name
 ```
 
 ### 出力形式
@@ -65,6 +72,37 @@ gcal calendars list --quiet
   }
 ]
 ```
+
+## テーブルフィールドのカスタマイズ
+
+`--fields`フラグを使用して、テーブル形式で表示する列をカスタマイズできます：
+
+### 利用可能なフィールド
+
+- `name` - カレンダー名/概要
+- `id` - カレンダーID
+- `access` - アクセス権限（owner、reader、writer等）
+- `primary` - プライマリカレンダー表示
+- `description` - カレンダー説明
+- `color` - カレンダーの色
+
+### 例
+
+```bash
+# 名前とIDのみ表示（最も一般的な用途）
+gcal calendars list --fields name,id
+
+# 名前、ID、アクセス権限を表示
+gcal calendars list --fields name,id,access
+
+# 名前のみ表示（クイック概要用）
+gcal calendars list --fields name
+
+# カレンダーの色とアクセス権限を表示
+gcal calendars list --fields name,color,access
+```
+
+**注意**: `--fields`フラグはテーブル形式の出力にのみ影響します。JSON出力は常にすべての利用可能なフィールドを含みます。
 
 ## 使用例
 

--- a/docs/ja/events-create.md
+++ b/docs/ja/events-create.md
@@ -27,6 +27,7 @@ gcal events create <summary> [options]
 | `--description` | | イベントの説明 | - |
 | `--attendees` | | 参加者メールアドレスのカンマ区切りリスト | - |
 | `--send-updates` | | イベント招待を送信（all/externalOnly/none） | `none` |
+| `--fields` | | テーブル形式で表示するフィールドのカンマ区切りリスト | すべてのフィールド |
 | `--format` | `-f` | 出力形式（table、json、pretty-json） | `table` |
 | `--quiet` | `-q` | 重要でない出力を非表示（ステータスメッセージ、進行状況表示） | `false` |
 

--- a/docs/ja/events-list.md
+++ b/docs/ja/events-list.md
@@ -19,6 +19,7 @@ gcal events list [calendar] [options]
 | フラグ | 短縮形 | 説明 | デフォルト |
 |--------|--------|------|-----------|
 | `--days` | `-d` | 先読みする日数（1-365） | `30` |
+| `--fields` | | テーブル形式で表示するフィールドのカンマ区切りリスト | すべてのフィールド |
 | `--format` | `-f` | 出力形式（table、json、pretty-json） | `table` |
 | `--max-results` | `-n` | 返却する最大イベント数（1-100） | `10` |
 | `--quiet` | `-q` | 重要でない出力を非表示（ステータスメッセージ、進行状況表示） | `false` |
@@ -65,6 +66,10 @@ gcal events list --quiet --format json | jq '.[] | .summary'
 gcal config set defaultCalendar work@company.com
 gcal config set events.days 14
 gcal events list  # work@company.comを14日間使用
+
+# テーブル列をカスタマイズ
+gcal events list --fields title,date,time
+gcal events list --fields title,location --max-results 20
 ```
 
 ### 出力形式
@@ -97,6 +102,33 @@ gcal events list  # work@company.comを14日間使用
   }
 ]
 ```
+
+## テーブルフィールドのカスタマイズ
+
+`--fields`フラグを使用して、テーブル形式で表示する列をカスタマイズできます：
+
+### 利用可能なフィールド
+
+- `title` - イベントタイトル/概要
+- `date` - イベント日付
+- `time` - イベント時間
+- `location` - イベント場所
+- `description` - イベント説明
+
+### 例
+
+```bash
+# タイトルと日付のみ表示
+gcal events list --fields title,date
+
+# タイトル、時間、場所を表示
+gcal events list --fields title,time,location
+
+# タイトルのみ表示（クイック概要用に便利）
+gcal events list --fields title
+```
+
+**注意**: `--fields`フラグはテーブル形式の出力にのみ影響します。JSON出力は常にすべての利用可能なフィールドを含みます。
 
 ## 時間範囲と制限
 

--- a/docs/ja/events-show.md
+++ b/docs/ja/events-show.md
@@ -19,6 +19,7 @@ gcal events show <event-id> [options]
 | フラグ | 短縮形 | 説明 | デフォルト |
 |--------|--------|------|-----------|
 | `--calendar` | `-c` | イベントが存在するカレンダーID | `primary` |
+| `--fields` | | テーブル形式で表示するフィールドのカンマ区切りリスト | すべてのフィールド |
 | `--format` | `-f` | 出力形式（table、json、pretty-json） | `table` |
 | `--quiet` | `-q` | 重要でない出力を非表示（ステータスメッセージ、進行状況表示） | `false` |
 

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -19,6 +19,7 @@ Google Calendar 작업을 위한 명령줄 인터페이스입니다. 터미널�
 - 🔐 **안전한 OAuth2 인증** - 일회성 설정으로 자동 토큰 갱신
 - 💻 **터미널 친화적 출력** - 스크립팅을 위한 깔끔한 테이블 형식 또는 JSON
 - 🔇 **조용한 모드 지원** - 스크립팅을 위해 `--quiet` 플래그로 상태 메시지 숨김
+- 🎯 **사용자 정의 테이블 열** - 테이블 형식에서 특정 열만 표시하려면 `--fields` 플래그 사용
 - 🚀 **빠르고 가벼움** - oclif 프레임워크로 구축
 
 ## 언어
@@ -117,6 +118,10 @@ gcal events list --max-results 5 --days 7
 
 # 스크립팅을 위한 조용한 모드 사용 (상태 메시지 숨김)
 gcal events list --quiet --format json | jq '.[] | .summary'
+
+# 테이블 열 사용자 정의
+gcal events list --fields title,date,time
+gcal calendars list --fields name,id
 
 # 구성 예제
 gcal config set defaultCalendar work@company.com

--- a/docs/ko/calendars-list.md
+++ b/docs/ko/calendars-list.md
@@ -12,6 +12,7 @@ gcal calendars list [옵션]
 
 | 플래그 | 단축 | 설명 | 기본값 |
 |--------|------|------|--------|
+| `--fields` | | 테이블 형식으로 표시할 필드의 쉼표 구분 목록 | 모든 필드 |
 | `--format` | `-f` | 출력 형식 (table, json, pretty-json) | `table` |
 | `--quiet` | `-q` | 필수가 아닌 출력 숨기기 (상태 메시지, 진행률 표시기) | `false` |
 
@@ -28,6 +29,12 @@ gcal calendars list --format json
 
 # 캘린더를 조용히 나열 (상태 메시지 없음)
 gcal calendars list --quiet
+
+# 캘린더 이름과 ID만 표시
+gcal calendars list --fields name,id
+
+# 이름만 표시 (빠른 개요용)
+gcal calendars list --fields name
 ```
 
 ### 출력 형식
@@ -65,6 +72,35 @@ gcal calendars list --quiet
   }
 ]
 ```
+
+## 테이블 필드 사용자 정의
+
+`--fields` 플래그를 사용하여 테이블 형식에서 표시될 열을 사용자 정의할 수 있습니다:
+
+### 사용 가능한 필드
+- `name` - 캘린더 이름/요약
+- `id` - 캘린더 ID
+- `access` - 액세스 역할 (owner, reader, writer 등)
+- `primary` - 기본 캘린더 표시기
+- `description` - 캘린더 설명
+- `color` - 캘린더 색상
+
+### 예제
+```bash
+# 이름과 ID만 표시 (가장 일반적인 사용 사례)
+gcal calendars list --fields name,id
+
+# 이름, ID 및 액세스 역할 표시
+gcal calendars list --fields name,id,access
+
+# 빠른 개요를 위해 이름만 표시
+gcal calendars list --fields name
+
+# 캘린더 색상과 액세스 표시
+gcal calendars list --fields name,color,access
+```
+
+**참고**: `--fields` 플래그는 테이블 형식 출력에만 영향을 줍니다. JSON 출력은 항상 사용 가능한 모든 필드를 포함합니다.
 
 ## 사용 사례
 

--- a/docs/ko/events-create.md
+++ b/docs/ko/events-create.md
@@ -27,6 +27,7 @@ gcal events create <요약> [옵션]
 | `--description` | | 이벤트 설명 | - |
 | `--attendees` | | 참석자 이메일 주소의 쉼표 구분 목록 | - |
 | `--send-updates` | | 이벤트 초대 보내기 (all/externalOnly/none) | `none` |
+| `--fields` | | 테이블 형식으로 표시할 필드의 쉼표 구분 목록 | 모든 필드 |
 | `--format` | `-f` | 출력 형식 (table, json, pretty-json) | `table` |
 | `--quiet` | `-q` | 필수가 아닌 출력 숨기기 (상태 메시지, 진행률 표시기) | `false` |
 

--- a/docs/ko/events-list.md
+++ b/docs/ko/events-list.md
@@ -19,6 +19,7 @@ gcal events list [캘린더] [옵션]
 | 플래그 | 단축 | 설명 | 기본값 |
 |--------|------|------|--------|
 | `--days` | `-d` | 미래로 조회할 일수 (1-365) | `30` |
+| `--fields` | | 테이블 형식으로 표시할 필드의 쉼표 구분 목록 | 모든 필드 |
 | `--format` | `-f` | 출력 형식 (table, json, pretty-json) | `table` |
 | `--max-results` | `-n` | 반환할 최대 이벤트 수 (1-100) | `10` |
 | `--quiet` | `-q` | 필수가 아닌 출력 숨기기 (상태 메시지, 진행률 표시기) | `false` |
@@ -65,6 +66,10 @@ gcal events list --quiet --format json | jq '.[] | .summary'
 gcal config set defaultCalendar work@company.com
 gcal config set events.days 14
 gcal events list  # 14일간 work@company.com 사용
+
+# 테이블 열 사용자 정의
+gcal events list --fields title,date,time
+gcal events list --fields title,location --max-results 20
 ```
 
 ### 출력 형식
@@ -97,6 +102,31 @@ gcal events list  # 14일간 work@company.com 사용
   }
 ]
 ```
+
+## 테이블 필드 사용자 정의
+
+`--fields` 플래그를 사용하여 테이블 형식에서 표시될 열을 사용자 정의할 수 있습니다:
+
+### 사용 가능한 필드
+- `title` - 이벤트 제목/요약
+- `date` - 이벤트 날짜
+- `time` - 이벤트 시간
+- `location` - 이벤트 위치
+- `description` - 이벤트 설명
+
+### 예제
+```bash
+# 제목과 날짜만 표시
+gcal events list --fields title,date
+
+# 제목, 시간, 위치 표시
+gcal events list --fields title,time,location
+
+# 제목만 표시 (빠른 개요용)
+gcal events list --fields title
+```
+
+**참고**: `--fields` 플래그는 테이블 형식 출력에만 영향을 줍니다. JSON 출력은 항상 사용 가능한 모든 필드를 포함합니다.
 
 ## 시간 범위 및 제한
 

--- a/docs/ko/events-show.md
+++ b/docs/ko/events-show.md
@@ -19,6 +19,7 @@ gcal events show <event-id> [옵션]
 | 플래그 | 단축 | 설명 | 기본값 |
 |--------|------|------|--------|
 | `--calendar` | `-c` | 이벤트가 존재하는 캘린더 ID | `primary` |
+| `--fields` | | 테이블 형식으로 표시할 필드의 쉼표 구분 목록 | 모든 필드 |
 | `--format` | `-f` | 출력 형식 (table, json, pretty-json) | `table` |
 | `--quiet` | `-q` | 필수가 아닌 출력 숨기기 (상태 메시지, 진행률 표시기) | `false` |
 

--- a/docs/pt/README.md
+++ b/docs/pt/README.md
@@ -19,6 +19,7 @@ Uma interface de linha de comando para operações do Google Calendar. Gerencie 
 - 🔐 **Autenticação OAuth2 segura** - Configuração única com atualização automática de token
 - 💻 **Saída amigável ao terminal** - Formato de tabela limpo ou JSON para scripts
 - 🔇 **Suporte ao modo silencioso** - Use a flag `--quiet` para suprimir mensagens de status em scripts
+- 🎯 **Colunas de tabela personalizáveis** - Use a flag `--fields` para mostrar apenas colunas específicas em formato de tabela
 - 🚀 **Rápido e leve** - Construído com o framework oclif
 
 ## Idiomas
@@ -115,6 +116,10 @@ gcal events list --max-results 5 --days 7
 
 # Usar modo silencioso para scripts (suprime mensagens de status)
 gcal events list --quiet --format json | jq '.[] | .summary'
+
+# Personalizar colunas de tabela
+gcal events list --fields title,date,time
+gcal calendars list --fields name,id
 
 # Exemplos de configuração
 gcal config set defaultCalendar work@company.com

--- a/docs/pt/calendars-list.md
+++ b/docs/pt/calendars-list.md
@@ -12,6 +12,7 @@ gcal calendars list [opções]
 
 | Flag | Abrev. | Descrição | Padrão |
 |------|--------|-----------|---------|
+| `--fields` | | Lista separada por vírgulas de campos a exibir em formato de tabela | Todos os campos |
 | `--format` | `-f` | Formato de saída (table, json, pretty-json) | `table` |
 | `--quiet` | `-q` | Ocultar saída não essencial (mensagens de status, indicadores de progresso) | `false` |
 
@@ -28,6 +29,12 @@ gcal calendars list --format json
 
 # Listar calendários silenciosamente (sem mensagens de status)
 gcal calendars list --quiet
+
+# Mostrar apenas nomes de calendários e IDs
+gcal calendars list --fields name,id
+
+# Mostrar apenas nomes (para visão geral rápida)
+gcal calendars list --fields name
 ```
 
 ### Formatos de saída
@@ -65,6 +72,35 @@ Calendários disponíveis (3 encontrados):
   }
 ]
 ```
+
+## Personalização de campos de tabela
+
+Você pode personalizar quais colunas são exibidas em formato de tabela usando a flag `--fields`:
+
+### Campos disponíveis
+- `name` - Nome/resumo do calendário
+- `id` - ID do calendário
+- `access` - Papel de acesso (owner, reader, writer, etc.)
+- `primary` - Indicador de calendário principal
+- `description` - Descrição do calendário
+- `color` - Cor do calendário
+
+### Exemplos
+```bash
+# Mostrar apenas nome e ID (caso de uso mais comum)
+gcal calendars list --fields name,id
+
+# Mostrar nome, ID e papel de acesso
+gcal calendars list --fields name,id,access
+
+# Mostrar apenas nomes para visão geral rápida
+gcal calendars list --fields name
+
+# Mostrar cores de calendários e acesso
+gcal calendars list --fields name,color,access
+```
+
+**Nota**: A flag `--fields` afeta apenas a saída em formato de tabela. A saída JSON sempre inclui todos os campos disponíveis.
 
 ## Casos de uso
 

--- a/docs/pt/events-create.md
+++ b/docs/pt/events-create.md
@@ -27,6 +27,7 @@ gcal events create <resumo> [opções]
 | `--description` | | Descrição do evento | - |
 | `--attendees` | | Lista separada por vírgulas de endereços de e-mail dos participantes | - |
 | `--send-updates` | | Enviar convites do evento (all/externalOnly/none) | `none` |
+| `--fields` | | Lista separada por vírgulas de campos a exibir em formato de tabela | Todos os campos |
 | `--format` | `-f` | Formato de saída (table, json, pretty-json) | `table` |
 | `--quiet` | `-q` | Ocultar saída não essencial (mensagens de status, indicadores de progresso) | `false` |
 

--- a/docs/pt/events-list.md
+++ b/docs/pt/events-list.md
@@ -19,6 +19,7 @@ gcal events list [calendário] [opções]
 | Flag | Abrev. | Descrição | Padrão |
 |------|--------|-----------|---------|
 | `--days` | `-d` | Número de dias para buscar no futuro (1-365) | `30` |
+| `--fields` | | Lista separada por vírgulas de campos a exibir em formato de tabela | Todos os campos |
 | `--format` | `-f` | Formato de saída (table, json, pretty-json) | `table` |
 | `--max-results` | `-n` | Número máximo de eventos a retornar (1-100) | `10` |
 | `--quiet` | `-q` | Ocultar saída não essencial (mensagens de status, indicadores de progresso) | `false` |
@@ -65,6 +66,10 @@ gcal events list --quiet --format json | jq '.[] | .summary'
 gcal config set defaultCalendar work@company.com
 gcal config set events.days 14
 gcal events list  # Usa work@company.com por 14 dias
+
+# Personalizar colunas de tabela
+gcal events list --fields title,date,time
+gcal events list --fields title,location --max-results 20
 ```
 
 ### Formatos de saída
@@ -97,6 +102,31 @@ Próximos eventos (2 encontrados):
   }
 ]
 ```
+
+## Personalização de campos de tabela
+
+Você pode personalizar quais colunas são exibidas em formato de tabela usando a flag `--fields`:
+
+### Campos disponíveis
+- `title` - Título/resumo do evento
+- `date` - Data do evento
+- `time` - Hora do evento
+- `location` - Local do evento
+- `description` - Descrição do evento
+
+### Exemplos
+```bash
+# Mostrar apenas título e data
+gcal events list --fields title,date
+
+# Mostrar título, hora e local
+gcal events list --fields title,time,location
+
+# Mostrar apenas títulos (para visão geral rápida)
+gcal events list --fields title
+```
+
+**Nota**: A flag `--fields` afeta apenas a saída em formato de tabela. A saída JSON sempre inclui todos os campos disponíveis.
 
 ## Intervalos de tempo e limites
 

--- a/docs/pt/events-show.md
+++ b/docs/pt/events-show.md
@@ -19,6 +19,7 @@ gcal events show <event-id> [opções]
 | Flag | Abrev. | Descrição | Padrão |
 |------|--------|-----------|---------|
 | `--calendar` | `-c` | ID do calendário onde o evento existe | `primary` |
+| `--fields` | | Lista separada por vírgulas de campos a exibir em formato de tabela | Todos os campos |
 | `--format` | `-f` | Formato de saída (table, json, pretty-json) | `table` |
 | `--quiet` | `-q` | Ocultar saída não essencial (mensagens de status, indicadores de progresso) | `false` |
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the `--fields` flag that was missing from all command documentation. The flag allows users to customize which columns are displayed in table format output.

## Changes Made

### Documentation Updates
- ✅ Added `--fields` flag to options tables for all commands (events-list, events-show, events-create, calendars-list)
- ✅ Added detailed "Table Field Customization" sections for events-list and calendars-list commands
- ✅ Updated feature descriptions in README files to highlight the customizable table columns capability
- ✅ Added usage examples showing how to use the `--fields` flag

### Languages Updated
- ✅ English (base documentation)
- ✅ Japanese (日本語)
- ✅ Spanish (Español)
- ✅ German (Deutsch)
- ✅ Portuguese (Português)
- ✅ French (Français)
- ✅ Korean (한국어)

## Key Features Documented

### Available Fields
- **Events**: `title`, `date`, `time`, `location`, `description`
- **Calendars**: `name`, `id`, `access`, `primary`, `description`, `color`

### Usage Examples
```bash
# Show only specific event fields
gcal events list --fields title,date,time

# Show only calendar names and IDs
gcal calendars list --fields name,id

# Show only event titles for quick overview
gcal events list --fields title
```

## Impact

- Improves user experience by documenting an existing but undocumented feature
- Provides clear guidance on table customization capabilities
- Maintains consistency across all 7 supported languages
- Aligns documentation with actual implementation

## Test plan

- [x] All existing functionality remains unchanged (documentation-only changes)
- [x] Documentation structure is consistent across all languages
- [x] Examples are accurate and reflect actual CLI behavior
- [x] Translation quality verified for all supported languages

🤖 Generated with [Claude Code](https://claude.ai/code)